### PR TITLE
introduced static_attr helper to simplify model declarations

### DIFF
--- a/app/models/note/base.rb
+++ b/app/models/note/base.rb
@@ -14,13 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'static_attributes'
+
 class Note::Base < ActiveRecord::Base
+  extend StaticAttributes
 
   self.table_name = 'notes'
 
   class_attribute :rdf_namespace, :rdf_predicate
   self.rdf_namespace = nil
   self.rdf_predicate = nil
+
+  static_attr "view_section", "notes"
+  static_attr "view_section_sort_key", 100
+  static_attr "partial_name", "partials/note/base"
+  static_attr "edit_partial_name", "partials/note/edit_base"
+  static_attr "search_result_partial_name", "partials/note/search_result"
 
   # ********** Validations
 
@@ -96,31 +105,11 @@ class Note::Base < ActiveRecord::Base
     "#{self.value}"
   end
 
-  def self.view_section(obj)
-    "notes"
-  end
-
-  def self.view_section_sort_key(obj)
-    100
-  end
-
-  def self.partial_name(obj)
-    "partials/note/base"
-  end
-
-  def self.edit_partial_name(obj)
-    "partials/note/edit_base"
-  end
-
   def self.single_query(params = {})
     query_str = build_query_string(params)
 
     by_query_value(query_str).
       by_language(params[:languages].to_a)
-  end
-
-  def self.search_result_partial_name
-    'partials/note/search_result'
   end
 
   def build_search_result_rdf(document, result)

--- a/app/models/note/skos/change_note.rb
+++ b/app/models/note/skos/change_note.rb
@@ -18,13 +18,8 @@ class Note::SKOS::ChangeNote < Note::SKOS::Base
 
   self.rdf_predicate = 'changeNote'
 
-  def self.edit_partial_name(obj)
-    "partials/note/skos/edit_change_note"
-  end
-
-  def self.search_result_partial_name
-    'partials/note/skos/change_note/search_result'
-  end
+  static_attr "edit_partial_name", "partials/note/skos/edit_change_note"
+  static_attr "search_result_partial_name", "partials/note/skos/change_note/search_result"
 
   def self.single_query(params = {})
     query_str = build_query_string(params)

--- a/app/models/note/skos/definition.rb
+++ b/app/models/note/skos/definition.rb
@@ -18,16 +18,8 @@ class Note::SKOS::Definition < Note::SKOS::Base
 
   self.rdf_predicate = 'definition'
 
-  def self.view_section(obj)
-    "main"
-  end
-
-  def self.view_section_sort_key(obj)
-    500 # Show near the end of the section
-  end
-
-  def self.search_result_partial_name
-    'partials/note/skos/definition/search_result'
-  end
+  static_attr "view_section", "main"
+  static_attr "view_section_sort_key", 500 # show near the end of the section
+  static_attr "search_result_partial_name", "partials/note/skos/definition/search_result"
 
 end

--- a/lib/static_attributes.rb
+++ b/lib/static_attributes.rb
@@ -1,0 +1,17 @@
+module StaticAttributes
+
+  def metaclass
+    class << self
+      self
+    end
+  end
+
+  def static_attr(name, value)
+    metaclass.instance_eval do
+      define_method name do |*args|
+        return value
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
I've always hated those single-expression methods; they're fugly and don't exactly help readability - so here's a (somewhat reluctant) suggestion for how to get rid of them

exemplified here using notes; there's plenty of potential in other models though:

```
$ pcregrep -rM ' def .*\n.*\n  *end' *
```
