### PR TITLE
fallback for label in dashboard

### DIFF
--- a/app/views/partials/concept/_edit_link_base.html.erb
+++ b/app/views/partials/concept/_edit_link_base.html.erb
@@ -1,4 +1,4 @@
-<% label = item.pref_label.to_s.presence || ":#{item.origin} (#{t("txt.common.translation_missing_for")} #{[I18n.locale.to_s, Iqvoc::Concept.pref_labeling_languages.first.to_s].uniq.join(", ")})" %>
+<% label = item.pref_label.to_s.presence || ":#{item.origin} [#{t("txt.common.translation_missing_for")} #{[I18n.locale.to_s, Iqvoc::Concept.pref_labeling_languages.first.to_s].uniq.join(", ")}]" %>
 <%= link_to truncate(label, :length => 45), (item.published? ? concept_path(:id => item.origin) : concept_path(:published => 0, :id => item.origin)) %>
 <%- if (item.additional_info) -%>
   (<%= item.additional_info %>)


### PR DESCRIPTION
there is no fallback for the shown label if the concept has no preflabel for the primary language
