### PR TITLE
Crashing iqvoc by configuring no language

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
 
   scope ':lang', :constraints => lambda { |params, req|
     lang = params[:lang]
-    return lang.to_s =~ /^#{Iqvoc::Concept.pref_labeling_languages.join("|")}$/
+    return lang.to_s =~ /^#{Iqvoc::Concept.pref_labeling_languages.join("|").presence || "en"}$/
   } do
 
     resource  :user_session, :only => [:new, :create, :destroy]


### PR DESCRIPTION
Don't try this in a real instance!

When you write nothing ("") into "availiable_languages" the instance will be broken until you reconfigure everything by database console. 
