### PR TITLE
Enabled caching in configuration

### DIFF
--- a/lib/iqvoc/instance_configuration.rb
+++ b/lib/iqvoc/instance_configuration.rb
@@ -95,6 +95,7 @@ module Iqvoc
     # populate settings caches
     # (subsequent updates will happen automatically via the respective setters)
     def initialize_cache
+      return if @settings
       # cache customized settings
       db_settings = ConfigurationSetting.all rescue [] # database table might not exist yet (pre-migration)
       db_settings.each do |setting|


### PR DESCRIPTION
This is done for two reasons:
1. Not using caching pollutes the logs.
2. Query-Caching < Caching. Even when AR caches the Querys the results have to be parsed and objectified.
