### PR TITLE
extensibility hook for language-dependent routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
     return params[:lang].to_s =~ /^#{langs}$/
   } do
 
+    Iqvoc.lang_routes.each { |hook| hook.call(self) }
+
     resource  :user_session, :only => [:new, :create, :destroy]
     resources :users, :except => [:show]
 

--- a/lib/iqvoc/configuration/core.rb
+++ b/lib/iqvoc/configuration/core.rb
@@ -14,7 +14,10 @@ module Iqvoc
           :first_level_class_configuration_modules,
           :ability_class_name,
           :navigation_items,
+          :lang_routes,
           :core_assets
+
+        self.lang_routes = [] # extensibility hook for language-dependent routes
 
         self.navigation_items = [
           {


### PR DESCRIPTION
this allows engines to register language-dependent routes without having to reimplement the language scope in their own `routes.rb` (cf. #196):

```
Iqvoc.lang_routes << lambda do |routing|
  routing.resources :stuff
  routing.get "foo" => "foo#show"
end
```

I played with a block-based approach similar to `Iqvoc.config`, but that didn't pan out.
