### PR TITLE
Concept: accept prefLabels in any primary language

### DIFF
--- a/app/models/collection/base.rb
+++ b/app/models/collection/base.rb
@@ -171,11 +171,12 @@ class Collection::Base < Concept::Base
     end
   end
 
-  def pref_label_in_primary_thesaurus_language
+  def pref_label_in_any_thesaurus_language
     labels = self.send(Iqvoc::Concept.pref_labeling_class_name.to_relation_name).map(&:target).select{|l| l.published?}
+    label_languages = labels.map(&:language).map(&:to_s)
     if labels.count == 0
       errors.add :base, I18n.t("txt.models.concept.no_pref_label_error")
-    elsif not labels.map(&:language).map(&:to_s).include?(Iqvoc::Concept.pref_labeling_languages.first.to_s)
+    elsif not Iqvoc::Concept.pref_labeling_languages.any?{|l| label_languages.include?(l)}
       errors.add :base, I18n.t("txt.models.concept.main_pref_label_language_missing_error")
     end
   end

--- a/app/models/concept/validations.rb
+++ b/app/models/concept/validations.rb
@@ -6,7 +6,7 @@ module Concept
       validates :origin, :presence => true, :on => :update
 
       validate :distinct_versions, :on => :create
-      validate :pref_label_in_primary_thesaurus_language, :on => :update
+      validate :pref_label_in_any_thesaurus_language, :on => :update
       validate :unique_pref_label_language
       validate :exclusive_top_term
       validate :rooted_top_terms
@@ -47,12 +47,13 @@ module Concept
       end
     end
 
-    def pref_label_in_primary_thesaurus_language
+    def pref_label_in_any_thesaurus_language
       if @full_validation
         labels = pref_labels.select{|l| l.published?}
+        label_languages = labels.map(&:language).map(&:to_s)
         if labels.count == 0
           errors.add :base, I18n.t("txt.models.concept.no_pref_label_error")
-        elsif not labels.map(&:language).map(&:to_s).include?(Iqvoc::Concept.pref_labeling_languages.first.to_s)
+        elsif not Iqvoc::Concept.pref_labeling_languages.any?{|l| label_languages.include?(l)}
           errors.add :base, I18n.t("txt.models.concept.main_pref_label_language_missing_error")
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -364,7 +364,7 @@ en:
        top_term_exclusive_error: "A Top Term must not have any broader terms."
        top_term_rooted_error: "Top Terms must not be used as narrower terms."
        invalid_rank_for_ranked_relations: 'Invalid rank for %{relation} "%{relation_target_label}".'
-       main_pref_label_language_missing_error: "There has to be one preferred Label in the main language of the thesaurus."
+       main_pref_label_language_missing_error: "There must be a preferred Label in at least one of the primary languages of the thesaurus."
        pref_labels_with_same_languages_error: "There must be only one preferred Label per language."
        association_pref_labels_unpublished: "The preferred Label has to be published."
        association_alt_labels_unpublished: "Alternative labels have to be published."

--- a/test/unit/concept_test.rb
+++ b/test/unit/concept_test.rb
@@ -48,13 +48,19 @@ class ConceptTest < ActiveSupport::TestCase
     assert !concept.valid_with_full_validation?
   end
 
-  test "published concept must have a pref_label of the first pref_label language configured (the main language)" do
+  test "published concept must have a pref_label of at least one of the pref_label languages configured" do
     concept = FactoryGirl.create(:concept)
     assert_equal 1, concept.pref_labels.count
     assert concept.valid_with_full_validation?
 
+    # Should validate if the only prefLabel language is in a non-primary pref_label language
     concept.pref_labels.first.language = Iqvoc::Concept.pref_labeling_languages.second
-    assert !concept.valid_with_full_validation?
+    assert concept.valid_with_full_validation?
+
+    # Should not validate if the only prefLabel language isn't any of the pref_label languages
+    refute Iqvoc::Concept.pref_labeling_languages.include? 'foo'
+    concept.pref_labels.first.language = 'foo'
+    refute concept.valid_with_full_validation?
   end
 
   test "concept shouldn't have more then one pref label of the same language" do


### PR DESCRIPTION
re: #200 - iQvoc rejects any concept which doesn't have a prefLabel in the thesaurus's primary language, even if it has a prefLabel in one of its other languages. This commit alters the behaviour so a term with at least one prefLabel in _any_ of the thesaurus's declared languages will be accepted.

I rewrote the English error message for the case when a term is missing, but I don't speak German or Portuguese so I wasn't able to change those. I also didn't change the name for the string (`main_pref_label_language_missing_error`), so you may want to do that.

(It looks like this behaviour wasn't covered by tests, and I didn't add one. I could add that in another commit.)
