### PR TITLE
adjusted name of note languages setting for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [TBD]
 
   * Improved instance configuration UI
+  * Adjusted internal name of note languages setting for consistency
 
 ## [4.1.2]
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -97,7 +97,7 @@ de:
          triplestore: Triplestore
        settings:
          title: Titel
-         note_languages: Sprachen für Notes
+         languages_notes: Sprachen für Notes
          languages_pref_labeling: Sprachen für bevorzugte Labels
          languages_further_labelings_Labeling::SKOS::AltLabel: Sprachen für alternative Labels
          triplestore_url: Triplestore-URL

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,7 +97,7 @@ en:
          triplestore: triplestore
        settings:
          title: site title
-         note_languages: languages for notes
+         languages_notes: languages for notes
          languages_pref_labeling: languages for preferred labels
          languages_further_labelings_Labeling::SKOS::AltLabel: languages for alternative labels
          triplestore_url: triplestore URL

--- a/db/migrate/20130508103137_adjust_note_languages_setting.rb
+++ b/db/migrate/20130508103137_adjust_note_languages_setting.rb
@@ -1,0 +1,17 @@
+class AdjustNoteLanguagesSetting < ActiveRecord::Migration
+
+  class ConfigSettings < ActiveRecord::Base
+    self.table_name = "configuration_settings"
+  end
+
+  def up
+    record = ConfigSettings.where("key" => "note_languages").first
+    record.update_attribute("key", "languages.notes") if record
+  end
+
+  def down
+    record = ConfigSettings.where("key" => "languages.notes").first
+    record.update_attribute("key", "note_languages") if record
+  end
+
+end

--- a/lib/iqvoc/configuration/core.rb
+++ b/lib/iqvoc/configuration/core.rb
@@ -113,7 +113,7 @@ module Iqvoc
           "title" => "iQvoc",
           "languages.pref_labeling" => ["en", "de"],
           "languages.further_labelings.Labeling::SKOS::AltLabel" => ["en", "de"],
-          "note_languages" => ["en", "de"]
+          "languages.notes" => ["en", "de"]
         })
       end
 
@@ -169,11 +169,14 @@ module Iqvoc
         end
 
         def note_languages
-          return config["note_languages"]
+          return config["languages.notes"]
         end
 
+        # returns a list of all languages selectable for labels and/or notes
         def all_languages
-          (Iqvoc::Concept.pref_labeling_languages + Iqvoc::Concept.further_labeling_class_names.values.flatten + note_languages).compact.map(&:to_s).uniq
+          (Iqvoc::Concept.pref_labeling_languages +
+              Iqvoc::Concept.further_labeling_class_names.values.flatten +
+              note_languages).compact.map(&:to_s).uniq
         end
 
         # @deprecated

--- a/test/integration/instance_configuration_test.rb
+++ b/test/integration/instance_configuration_test.rb
@@ -37,9 +37,9 @@ class InstanceConfigurationTest < ActionDispatch::IntegrationTest
     visit uri
     assert_equal "/en/config.html", page.current_path
     assert page.has_css?("input#config_title")
-    assert page.has_css?("input#config_note_languages")
     assert page.has_selector?(:xpath, '//input[@id="config_languages.pref_labeling"]')
     assert page.has_selector?(:xpath, '//input[@id="config_languages.further_labelings.Labeling::SKOS::AltLabel"]')
+    assert page.has_selector?(:xpath, '//input[@id="config_languages.notes"]')
 
     # TODO: also test POST
   end


### PR DESCRIPTION
see commit message

note the migration uses a dummy class to avoid accessing the model - is there simpler way?
