### PR TITLE
importer can't handle empty strings

### DIFF
--- a/app/models/labeling/skos/base.rb
+++ b/app/models/labeling/skos/base.rb
@@ -84,7 +84,7 @@ class Labeling::SKOS::Base < Labeling::Base
 
   def self.build_from_rdf(rdf_subject, rdf_predicate, rdf_object)
     raise "#{self.name}#build_from_rdf: Subject (#{rdf_subject}) must be a Concept."     unless rdf_subject.is_a?(Concept::Base)
-    warn "#{self.name}#build_from_rdf: Object (#{rdf_object}) must be a string literal" unless rdf_object =~ /^"(.+)"(@(.+))?$/
+    raise MustBeStringLiteralError, "#{self.name}#build_from_rdf: Object (#{rdf_object}) must be a string literal" unless rdf_object =~ /^"(.+)"(@(.+))?$/
 
     lang = $3
     value = begin
@@ -108,4 +108,12 @@ class Labeling::SKOS::Base < Labeling::Base
     build_rdf(document, result)
   end
 
+end
+
+class MustBeStringLiteralError < StandardError
+  attr_reader :original
+  def initialize(msg, original = $!)
+    super(msg)
+    @original = original;
+  end
 end

--- a/lib/iqvoc/skos_importer.rb
+++ b/lib/iqvoc/skos_importer.rb
@@ -186,8 +186,11 @@ module Iqvoc
           return false
         end
       end
-
-      types[predicate].build_from_rdf(subject, predicate, object)
+      begin
+        types[predicate].build_from_rdf(subject, predicate, object)
+      rescue MustBeStringLiteralError => e
+        warn e.message
+      end
     end
 
     def load_first_level_object(origin)
@@ -228,4 +231,5 @@ module Iqvoc
 
     ActiveSupport.run_load_hooks(:skos_importer, self)
   end
+
 end

--- a/test/unit/skos_import_test.rb
+++ b/test/unit/skos_import_test.rb
@@ -224,6 +224,5 @@ class SkosCollectionImportTest < ActiveSupport::TestCase
       end
     end
   end
-
 end
 


### PR DESCRIPTION
re: #249 - The importer can't handle empty strings and raises an error. I have changed the statement to just raise a warning. Maybe it's even better to just adjust the regular expression in this statement to accept empty strings, not 100% sure about it. (I tried, but I fear my try doesn't only allow empty strings, but also invalid RDF strings...)
I have also written a test for this case.
