### PR TITLE
#177 deprecate warning for template handling

### DIFF
--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -74,8 +74,8 @@ class SearchResultsController < ApplicationController
 
       respond_to do |format|
         format.html
-        format.ttl { render('search_results/index.iqrdf') }
-        format.rdf { render('search_results/index.iqrdf') }
+        format.ttl { render :handlers => [:iqrdf] }
+        format.rdf { render :handlers => [:iqrdf] }
       end
 
     end


### PR DESCRIPTION
#177: Template Handler adjusted to remove deprecation warning when running `rake test`.
