### PR TITLE
Move collections to default namespace

### DIFF
--- a/app/helpers/rdf_helper.rb
+++ b/app/helpers/rdf_helper.rb
@@ -27,7 +27,7 @@ module RdfHelper
 
       concept.collection_members.each do |collection_member|
         if @rdf_helper_cached_collections[collection_member.collection_id]
-          c.Schema::memberOf(IqRdf::Coll::build_uri(@rdf_helper_cached_collections[collection_member.collection_id]))
+          c.Schema::memberOf(IqRdf.build_uri(@rdf_helper_cached_collections[collection_member.collection_id]))
         end
       end
 
@@ -88,7 +88,7 @@ module RdfHelper
       end
 
       collection.subcollections.each do |subcollection|
-        c.Skos::member(IqRdf::Coll.build_uri(subcollection.origin))
+        c.Skos::member(IqRdf.build_uri(subcollection.origin))
       end
 
     end

--- a/app/helpers/rdf_namespaces_helper.rb
+++ b/app/helpers/rdf_namespaces_helper.rb
@@ -4,7 +4,6 @@ module RdfNamespacesHelper
   def iqvoc_default_rdf_namespaces
     Iqvoc.rdf_namespaces.merge({
       default: root_url(format: nil, lang: nil, trailing_slash: true),
-      coll: rdf_collections_url(trailing_slash: true, lang: nil, format: nil),
       schema: schema_url(format: nil, anchor: '', lang: nil)
     })
   end

--- a/app/models/collection/base.rb
+++ b/app/models/collection/base.rb
@@ -83,7 +83,7 @@ class Collection::Base < Concept::Base
   end
 
   def build_rdf_subject(&block)
-    IqRdf::Coll::build_uri(self.origin, IqRdf::Skos::build_uri('Collection'), &block)
+    IqRdf.build_uri(self.origin, IqRdf::Skos::build_uri('Collection'), &block)
   end
 
   def inline_member_concept_origins=(origins)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,5 @@ Rails.application.routes.draw do
 
   get ':id' => 'rdf#show', as: 'rdf'
 
-  get 'collections', as: 'rdf_collections', to: 'collections#index'
-
   root to: 'frontpage#index', format: nil
 end


### PR DESCRIPTION
Currently collections are referenced in the default namespace but referencing concepts use a separate collection-namespace (<DEFAULT_NAMESPACE>/collections). This PR removes the collection-namespace and strictly uses the default namespace for collections.
## Example:

```
# a collection
@prefix : <http://try.iqvoc.net/>.
@prefix skos: <http://www.w3.org/2004/02/skos/core#>.

:indoors a skos:Collection;  # <------- collection in default namespace
         skos:prefLabel "indoors"@en;
         skos:member :audiophilia;
...
```

```
# a concept
@prefix : <http://try.iqvoc.net/>.
@prefix coll: <http://try.iqvoc.net/collections/>.
@prefix schema: <http://try.iqvoc.net/schema#>.
@prefix skos: <http://www.w3.org/2004/02/skos/core#>.

:achievement_hobbies skos:prefLabel "Achievement hobbies"@en.
:amateur_radio a skos:Concept;
               schema:memberOf coll:indoors;  # <------- Parent collection in :coll-namespace
               skos:inScheme :scheme;
               skos:prefLabel "Amateur radio"@en;
               skos:broader :achievement_hobbies.
```
