### PR TITLE
Onebox optimizations

### DIFF
--- a/app/assets/javascripts/iqvoc/onebox.js.erb
+++ b/app/assets/javascripts/iqvoc/onebox.js.erb
@@ -9,7 +9,7 @@ function OneBox(container) {
   this.container = container.jquery ? container : $(container);
   this.form = this.container.find('form');
   this.input = $(".onebox-input", this.form); // TODO: document
-  this.results = $('<ol class="results concept-items list-unstyled" />');
+  this.results = $('<ol class="search-results list-unstyled" />');
   this.indicator = $('<i class="fa fa-refresh fa-spin fa-3x onebox-indicator" />').
       appendTo(this.container).hide();
 
@@ -21,7 +21,7 @@ OneBox.prototype.reset = function() {
 };
 OneBox.prototype.renderResults = function(html) {
   var doc = $("<div />").append(html);
-  var items = $(".concept-items > li", doc);
+  var items = $(".search-results > li", doc);
   var pagination = $(".pagination", doc);
 
   this.reset();

--- a/app/assets/javascripts/iqvoc/onebox.js.erb
+++ b/app/assets/javascripts/iqvoc/onebox.js.erb
@@ -31,7 +31,8 @@ OneBox.prototype.renderResults = function(html) {
 OneBox.prototype.onInput = function(ev) {
   var val = this.input.val();
   this.reset();
-  if(val.length > 0 && val !== this.initialValue) {
+  // start search if there are at least two characters in onebox
+  if(val.length >= 2 && val !== this.initialValue) {
     this.getConcepts();
   }
 };

--- a/app/assets/javascripts/iqvoc/onebox.js.erb
+++ b/app/assets/javascripts/iqvoc/onebox.js.erb
@@ -28,9 +28,6 @@ OneBox.prototype.renderResults = function(html) {
   this.results.empty().append(items).appendTo(this.container);
   pagination.appendTo(this.container);
 };
-OneBox.prototype.onSubmit = function(ev) {
-  ev.preventDefault(); // handled by #onInput
-};
 OneBox.prototype.onInput = function(ev) {
   var val = this.input.val();
   this.reset();

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -166,5 +166,11 @@ class SearchResultsController < ApplicationController
 
     collections = Iqvoc::Collection.base_class.includes(:pref_labels).load
     controller.instance_variable_set(:@collections, collections)
+
+    # default search params
+    controller.params['t'] = 'labels' if controller.params['t'].nil?
+    controller.params['qt'] = 'contains' if controller.params['qt'].nil?
+    controller.params['for'] = 'all' if controller.params['for'].nil?
+    controller.params['l'] = langs.keys if controller.params['l'].nil?
   end
 end

--- a/app/views/frontpage/index.html.erb
+++ b/app/views/frontpage/index.html.erb
@@ -1,11 +1,11 @@
 <%= render 'title' %>
 <div class="onebox">
-  <%= form_tag alphabetical_concepts_path(:prefix => nil), :method => :get, :class => "onebox-form" do %>
-          <div class="onebox-input-wrapper">
-            <%= search_field_tag "prefix", nil, :id => nil,
-                  :class => "form-control onebox-input",
-                  :autofocus => true,
-                  :placeholder => t("txt.views.frontpage.type_to_browse") %>
-          </div>
-  <% end %>
+  <%= form_tag search_path(:q => nil), :method => :get, :class => "onebox-form" do %>
+    <div class="onebox-input-wrapper">
+      <%= search_field_tag "q", nil, :id => nil,
+        :class => "form-control onebox-input",
+        :autofocus => true,
+        :placeholder => t("txt.views.frontpage.type_to_browse") %>
+  </div>
+<% end %>
 </div>


### PR DESCRIPTION
Onebox input should find all entities which contains search term. Currently it lists only entities which start with current term.

![search](https://cloud.githubusercontent.com/assets/1260530/6728722/314657f0-ce2c-11e4-873c-bbf0b1b20636.gif)


