### PR TITLE
iQvoc allows concept creation which are not consistent to skos data model

### DIFF
--- a/app/models/concept/validations.rb
+++ b/app/models/concept/validations.rb
@@ -66,8 +66,8 @@ module Concept
       if validatable_for_publishing?
         # checks if there are any existing pref labels with the same
         # language and value
-        conflicting_pref_labels = labels.select do |l|
-          Labeling::Base.
+        conflicting_pref_labels = pref_labels.select do |l|
+          Labeling::SKOS::Base.
             joins(:owner, :target).
             where(labels: { value: l.value, language: l.language }).
             where('labelings.owner_id != ?', id).

--- a/app/models/label/base.rb
+++ b/app/models/label/base.rb
@@ -84,6 +84,18 @@ class Label::Base < ActiveRecord::Base
     self.to_s.downcase <=> other.to_s.downcase
   end
 
+  def ==(other)
+    language == other.language && value == other.value
+  end
+
+  def eql?(other)
+    self == other
+  end
+
+  def hash
+    [value, language].hash
+  end
+
   def to_literal
     "\"#{value}\"@#{language}"
   end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -429,3 +429,5 @@ de:
        no_pref_label: "-- kein PrefLabel --"
        pref_label_not_unique: "Das PrefLabel %{label} ist bereits in Verwendung."
        pref_labels_not_unique: "Die PrefLabels %{label} sind bereits in Verwendung."
+       pref_label_defined_in_alt_labels: "Das AltLabel %{label} wird bereits als PrefLabel verwendet."
+       alt_labels_not_unique: "Das AltLabel %{label} wird zweimal als AltLabel verwendet."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,3 +435,5 @@ en:
        no_pref_label: "-- no PrefLabel --"
        pref_label_not_unique: "The preferred label '%{label}' is already in use."
        pref_labels_not_unique: "The preferred labels '%{label}' are already in use."
+       pref_label_defined_in_alt_labels: "The alternative label %{label} is already used as a preferred label."
+       alt_labels_not_unique: "The alternative label %{label} is used twice."

--- a/test/models/concept_test.rb
+++ b/test/models/concept_test.rb
@@ -100,6 +100,35 @@ class ConceptTest < ActiveSupport::TestCase
     refute bear_two.publishable?
   end
 
+  test 'unique alt labels' do
+    tiger = RDFAPI.devour 'tiger', 'a', 'skos:Concept'
+    RDFAPI.devour tiger, 'skos:prefLabel', '"Tiger"@en'
+
+    assert tiger.save
+    assert tiger.publishable?
+
+    # two identical alt labels
+    RDFAPI.devour tiger, 'skos:altLabel', '"Big cat"@en'
+    RDFAPI.devour tiger, 'skos:altLabel', '"Big cat"@en'
+
+    tiger.save!
+    refute tiger.publishable?, 'There should be no identical alt labels'
+  end
+
+  test 'distinct labels' do
+    monkey = RDFAPI.devour 'Monkey', 'a', 'skos:Concept'
+    RDFAPI.devour monkey, 'skos:prefLabel', '"Monkey"@en'
+
+    assert monkey.save
+    assert monkey.publishable?
+
+    # identical to pref label
+    RDFAPI.devour monkey, 'skos:altLabel', '"Monkey"@en'
+
+    monkey.save!
+    refute monkey.publishable?, 'There should be no duplicates between prefLabel/altLabel'
+  end
+
   test 'multiple pref labels' do
     concept = RDFAPI.devour 'bear', 'a', 'skos:Concept'
     RDFAPI.devour concept, 'skos:prefLabel', '"Bear"@en'


### PR DESCRIPTION
Currently iQvoc allows concept creation which are not consistent with the SKOS data model.

See spec for more details: http://www.w3.org/TR/skos-reference/#L1409. 

[iqvoc_skosxl](https://github.com/innoq/iqvoc_skosxl) might be also affected.

### PrefLabel/AltLabel clash

![screen shot 2015-05-12 at 15 38 57](https://cloud.githubusercontent.com/assets/1260530/7588432/5c117684-f8bd-11e4-9daf-881c6ade5fac.png)

### Duplicate AltLabel clash

![screen shot 2015-05-12 at 15 40 23](https://cloud.githubusercontent.com/assets/1260530/7588441/6a004428-f8bd-11e4-84a3-075fc999658b.png)